### PR TITLE
Make template filter run each time

### DIFF
--- a/django_assets/filter.py
+++ b/django_assets/filter.py
@@ -15,6 +15,7 @@ class TemplateFilter(Filter):
     """
 
     name = 'template'
+    max_debug_level = None
 
     def __init__(self, context=None):
         super(TemplateFilter, self).__init__()


### PR DESCRIPTION
Since Django template tags are invalid CSS/JS syntax even in development mode, template filter needs to run always.
