### PR TITLE
Encode Django's template engine's output to UTF-8 since it breaks otherwise

### DIFF
--- a/django_assets/filter.py
+++ b/django_assets/filter.py
@@ -23,7 +23,7 @@ class TemplateFilter(Filter):
 
     def input(self, _in, out, source_path, output_path, **kw):
         t = Template(_in.read(), origin='django-assets', name=source_path)
-        out.write(t.render(Context(self.context if self.context else {}) ))
+        out.write(t.render(Context(self.context if self.context else {}) ).encode('utf-8'))
 
 
 register_filter(TemplateFilter)


### PR DESCRIPTION
This is useful when assets contain non-ASCII characters, one example if jQuery UI's i18n files which are necessarily encoded in UTF-8
