### PR TITLE
Add plugin that initialises django_assets in pytest

### DIFF
--- a/django_assets/pytest_plugin.py
+++ b/django_assets/pytest_plugin.py
@@ -1,0 +1,7 @@
+import pytest
+import django_assets.env
+
+@pytest.fixture(autouse=True)
+def set_django_assets_env():
+    print "Set django assets environment"
+    django_assets.env.get_env() # initialise django-assets settings

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,10 @@ setup(
     tests_require=[
         'nose',
     ],
+    # make plugin available to pytest
+    entry_points = {
+        'pytest11': [
+            'name_of_plugin = django_assets.pytest_plugin',
+        ]
+    },
 )


### PR DESCRIPTION
This ensures that django_assets configuration settings are not removed after
each pytest test run.
