### PR TITLE
Support for depends in Bundle and Django template tags

### DIFF
--- a/django_assets/env.py
+++ b/django_assets/env.py
@@ -145,7 +145,7 @@ class DjangoResolver(Resolver):
         except ImportError:
             # Support pre-1.3 versions.
             finders = None
-    
+
         # Use the staticfiles finders to determine the absolute path
         if finders:
             if has_magic(item):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,9 @@ simply define everything inside your template:
         <script type="text/javascript" src="{{ ASSET_URL }}"></script>
     {% endassets %}
 
+You can also pass in ``depends`` through templatetags with a slightly
+modified comma-delimated syntax, e.g.
+``depends="myfile.js,path/to/file.js"``.
 
 The management command
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Preserves @acttao's original commit at #4 
- Against master
- Support for comma-delimited strings for ``depends`` in django template tags, and updates the docs for that.