### PR TITLE
Don't include 'tests' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description='Asset management for Django, to compress and merge '\
                 'CSS and Javascript files.',
     long_description=__doc__,
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     zip_safe=False,
     platforms='any',
     install_requires=[


### PR DESCRIPTION
Installing `django-assets` adds `tests` in site-packages since `find_packages` is finding it and shipping it to PyPi. Found this with some code doing relative imports.

Tested the `find_packages` change in python shell.