### PR TITLE
Integrate with Django's ManifestStaticFileStorage

### DIFF
--- a/django_assets/management/commands/assets.py
+++ b/django_assets/management/commands/assets.py
@@ -32,7 +32,7 @@ from webassets.script import (CommandError as AssetCommandError,
                               GenericArgparseImplementation)
 from django_assets.env import get_env, autoload
 from django_assets.loaders import get_django_template_dirs, DjangoLoader
-
+from django_assets.manifest import DjangoManifest  # noqa: enables the --manifest django option
 
 try:
     from django.core.management import LaxOptionParser

--- a/django_assets/manifest.py
+++ b/django_assets/manifest.py
@@ -1,0 +1,59 @@
+import os
+
+from webassets.version import Manifest
+
+try:
+    from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+    class DjangoManifest(Manifest):
+        """Stores version data in Django's ManifestStaticFileStorage.
+
+        Requires Django 1.7 or later.
+        """
+
+        id = 'django'
+
+        def __init__(self, *a, **kw):
+            try:
+                import json
+            except ImportError:
+                import simplejson as json
+            self.json = json
+            self.storage = ManifestStaticFilesStorage()
+            self._load_manifest()
+
+        def remember(self, bundle, ctx, version):
+            output_filename = bundle.resolve_output(ctx, version=version)
+            output_filename = os.path.relpath(output_filename, ctx.directory)
+            source_filename = self.name_without_hash(bundle.output)
+
+            self.storage.hashed_files[source_filename] = output_filename
+            self._save_manifest()
+
+        def query(self, bundle, ctx):
+            if ctx.auto_build:
+                self._load_manifest()
+
+            source_filename = self.name_without_hash(bundle.output)
+            output = self.storage.hashed_files.get(source_filename, None)
+            if output:
+                # foo.hash.js
+                name_with_hash, ext = os.path.splitext(output)
+                output = os.path.splitext(name_with_hash)[1]
+
+            return output
+
+        def name_without_hash(self, filename):
+            name_with_hash, ext = os.path.splitext(filename)
+            name = os.path.splitext(name_with_hash)[0]
+            return name + ext
+
+        def _load_manifest(self):
+            self.storage.load_manifest()
+
+        def _save_manifest(self):
+            self.storage.save_manifest()
+
+except ImportError:
+    class DjangoManifest(object):
+        pass

--- a/docs/staticfiles.rst
+++ b/docs/staticfiles.rst
@@ -92,3 +92,16 @@ define an ``ASSETS_ROOT`` setting that points to a different directory
 then ``STATIC_ROOT``. Only then will ``collectstatic`` be able to find the
 output files created with ``./manage.py build --parse-templates``, and
 process them into ``STATIC_ROOT``, like any other static file.
+
+``ManifestStaticFileStorage`` or White Noise
+--------------------------------------------
+
+If you are using Django's ``ManifestStaticFilesStorage`` or White Noise's
+``GzipManifestStaticFilesStorage`` then you must build your assets after
+calling ``collectstatic`` using the ``--manifest django`` option::
+
+    ./manage.py assets build --manifest django
+    
+This will add the built assets to Django's static files manifest. In particular,
+this ensures that White Noise realises they are cacheable static files and
+will add appropriate far-future expiry headers when serving them.


### PR DESCRIPTION
Ensure's that White Noise realises these are cacheable assets and adds appropriate far-future expiry headers.

This requires Django 1.7 or later. I'm open to suggestions for how to add that into the code. Currently the option is silently ignored if the imports fail.

Fixes #56