### PR TITLE
Determine to use staticfiles finders based on DEBUG

### DIFF
--- a/django_assets/env.py
+++ b/django_assets/env.py
@@ -105,7 +105,7 @@ class DjangoResolver(Resolver):
 
     @property
     def use_staticfiles(self):
-        return settings.ASSETS_DEBUG and \
+        return settings.DEBUG and \
             'django.contrib.staticfiles' in settings.INSTALLED_APPS
 
     def glob_staticfiles(self, item):


### PR DESCRIPTION
Using ASSET_DEBUG, IMO, is the wrong way to decide on using staticfiles or not. django-assets should behave the same as staticfiles in how it finds files.