### PR TITLE
Pytest fixes

### DIFF
--- a/django_assets/pytest_plugin.py
+++ b/django_assets/pytest_plugin.py
@@ -3,5 +3,4 @@ import django_assets.env
 
 @pytest.fixture(autouse=True)
 def set_django_assets_env():
-    print("Set django assets environment")
     django_assets.env.get_env() # initialise django-assets settings

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     # make plugin available to pytest
     entry_points = {
         'pytest11': [
-            'name_of_plugin = django_assets.pytest_plugin',
+            'django_assets = django_assets.pytest_plugin',
         ]
     },
 )


### PR DESCRIPTION
Fixes #71.

* Change plugin name to `django_assets`
* Stop `print` on every test run.