### PR TITLE
Travis - remove Django 1.7 environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 python: 2.7
 env:
-  - TOX_ENV=django17-py27
-  - TOX_ENV=django17-py33
-  - TOX_ENV=django17-py34
-  - TOX_ENV=django17-pypy
-
   - TOX_ENV=django18-py27
   - TOX_ENV=django18-py33
   - TOX_ENV=django18-py34


### PR DESCRIPTION
These should have been removed in 3faa97d6f8f758f785902c90a78af40163f5bb48.