### PR TITLE
Fix indentation with tab instead of spaces

### DIFF
--- a/django_assets/management/commands/assets.py
+++ b/django_assets/management/commands/assets.py
@@ -37,7 +37,7 @@ from django_assets.manifest import DjangoManifest  # noqa: enables the --manifes
 
 class Command(BaseCommand):
     help = 'Manage assets.'
-	requires_system_checks = False
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         # parser.add_argument('poll_id', nargs='+', type=str)


### PR DESCRIPTION
There are a number of flake8 errors in the repo but this one can break the source under a number of transformations like minification. Spotted this when looking at the changes for #74.

Also checked the rest of the repo for tabs/spaces problems.