### PR TITLE
Correct windows paths bleed into urls

### DIFF
--- a/django_assets/env.py
+++ b/django_assets/env.py
@@ -149,6 +149,8 @@ class DjangoResolver(Resolver):
         # parent implementation does, will not help. Instead, we can
         # assume that the url is the root url + the original relative
         # item that was specified (and searched for using the finders).
+        import os
+        item = item.replace(os.sep, "/")
         return url_prefix_join(ctx.url, item)
 
 


### PR DESCRIPTION
When debugging in windows, file paths need's to with windows separators but leaving them as-is in urls's cause Firefox to not loading assets.

