### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,6 @@ Integrates the `webassets`_ library with Django, adding support for
 merging, minifying and compiling CSS and Javascript files.
 
 Documentation:
-    http://django-assets.readthedocs.org/
+    https://django-assets.readthedocs.io/
 
 .. _webassets: http://github.com/miracle2k/webassets


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.