### PR TITLE
Make tests run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist = django18-{py27,py33,py34,pypy}, django19-{py27,py34,py35}
 
 [testenv]
 commands = nosetests {posargs}
-install_command = pip install --pre --allow-external webassets --allow-unverified webassets {opts} {packages}
+install_command = pip install --pre {opts} {packages}
 
 deps =
     nose==1.3.7
-    webassets==dev
     ipdb>=0.8.0
+    https://github.com/miracle2k/webassets/archive/master.tar.gz
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
The tests currently don't start on master when running `tox`, erroring with:

```
DEPRECATION: --allow-external has been deprecated and will be removed in the future. Due to changes in the repository protocol, it no longer has any effect.
DEPRECATION: --allow-unverified has been deprecated and will be removed in the future. Due to changes in the repository protocol, it no longer has any effect.
Collecting nose==1.3.7
  Using cached nose-1.3.7-py2-none-any.whl
Collecting webassets==dev
  Could not find a version that satisfies the requirement webassets==dev (from versions: 0.4, 0.5, 0.6, 0.7, 0.7.1, 0.8, 0.9, 0.10, 0.10.1, 0.11, 0.11.1, 0.12.0)
No matching distribution found for webassets==dev
```

I've removed the deprecated `pip` flags and made the `webassets` dev version install from the Github master via a tarball, assuming that's what it was doing before through the now missing `dev` version on PyPI.

There are still failures in the test suite after this though:

```
======================================================================
FAIL: tests.test_django.TestLoader.test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/adamj/Documents/Projects/django-assets/.tox/django19-py35/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/adamj/Documents/Projects/django-assets/tests/test_django.py", line 192, in test
    assert len(bundles) == 1
AssertionError

======================================================================
FAIL: tests.test_django.TestLoader.test_cached_loader
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/adamj/Documents/Projects/django-assets/.tox/django19-py35/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/adamj/Documents/Projects/django-assets/tests/test_django.py", line 202, in test_cached_loader
    assert len(bundles) == 1
AssertionError

----------------------------------------------------------------------
Ran 19 tests in 0.578s
```