### PR TITLE
Strip leading "." from versioned file name

### DIFF
--- a/django_assets/manifest.py
+++ b/django_assets/manifest.py
@@ -37,7 +37,7 @@ try:
             if output:
                 # foo.hash.js
                 name_with_hash, ext = os.path.splitext(output)
-                output = os.path.splitext(name_with_hash)[1]
+                output = os.path.splitext(name_with_hash)[1].strip('.')
 
             return output
 


### PR DESCRIPTION
splitext() will return the version as ".HASH", so the leading period needs to be stripped.

Fixes #90.