### PR TITLE
Added ppc64le arch support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,10 @@ script:
 branches:
   only:
     - master
+arch:
+  - amd64
+  - ppc64le
+jobs:
+  allow_failures:
+    - arch: ppc64le
+      python: pypy3


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. Also I had added jobs in allowed failure as pypy3 is not supported on the ppc64le architecture so far. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/kishorkunal-raj/django-assets/builds/186386579

Please have a look.

Regards,
Kishor Kunal Raj