### PR TITLE
Fix issue with running  in Django 4.1

### DIFF
--- a/django_assets/management/commands/assets.py
+++ b/django_assets/management/commands/assets.py
@@ -37,7 +37,7 @@ from django_assets.manifest import DjangoManifest  # noqa: enables the --manifes
 
 class Command(BaseCommand):
     help = 'Manage assets.'
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser):
         # parser.add_argument('poll_id', nargs='+', type=str)


### PR DESCRIPTION
Resolves #102

This fixes an issue where `assets build` can't be run when using Django 4.1 due to a deprecated field.
