### PR TITLE
Fix issue with Python 3.11

### DIFF
--- a/django_assets/glob.py
+++ b/django_assets/glob.py
@@ -121,7 +121,7 @@ def translate(pat):
                 res = '%s([%s])' % (res, stuff)
         else:
             res = res + re.escape(c)
-    return res + '\Z(?ms)'
+    return '(?ms)' + res + '\Z'
 
 
 """Filename globbing utility."""


### PR DESCRIPTION
This fixes a crash on Python 3.11. Global flags in regexes must now be put at the beginning.

This is the error message for the exception that this PR fixes:
`re.error: global flags not at the start of the expression at position 12`

Resolves #98