### PR TITLE
Iterate over nodes and templates using nodelist

### DIFF
--- a/django_assets/loaders.py
+++ b/django_assets/loaders.py
@@ -107,6 +107,6 @@ class DjangoLoader(GlobLoader):
                     and node.nodelist\
                     or []:
                         _recurse_node(subnode)
-            for node in t:  # don't move into _recurse_node, ``Template`` has a .nodelist attribute
+            for node in t.nodelist:  # don't move into _recurse_node, ``Template`` has a .nodelist attribute
                 _recurse_node(node)
             return result


### PR DESCRIPTION
When iterating over Template and Node objects directly, nodes may fail with an exception such as:
TypeError: 'TextNode' object is not iterable
This is due to iterating over nodes being unsupported in Django, as noted in https://code.djangoproject.com/ticket/7430
To avoid this error, explicitly iterate over the nodelist attribute, rather than relying on __iter__.

This fixes the issue seen in #101 